### PR TITLE
sanitizing group links

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,6 +34,11 @@ class Facebook:
     def group_pages(self):
         for i in range(len(self.groups)):
             self.link = self.groups[i]
+            self.link = self.link.replace(' ', '')
+            if self.link[-1] == '/':
+                self.link = self.link
+            else:
+                self.link += '/'
             self.driver.get(self.link)
             self.description()
             # self.image()


### PR DESCRIPTION
The group links may contain whitespace due to the user not being able to decide whether to put space after/before a comma or not.
To ensure the links do not contain whitespace here is the PR.

closes #22 